### PR TITLE
feat: enforce object shorthand

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -104,7 +104,7 @@ module.exports = {
         // object keys
         'sort-keys': 'off',
         'sort-keys/sort-keys-fix': 'warn',
-        'object-shorthand': ['warn', 'always'],
+        'object-shorthand': ['warn', 'always', { avoidQuotes: true }],
 
         // React
         'react/react-in-jsx-scope': 'off',

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -101,9 +101,10 @@ module.exports = {
             }
         ],
 
-        // Sort object keys
+        // object keys
         'sort-keys': 'off',
         'sort-keys/sort-keys-fix': 'warn',
+        'object-shorthand': ['warn', 'always'],
 
         // React
         'react/react-in-jsx-scope': 'off',
@@ -125,7 +126,7 @@ module.exports = {
         // Security
         'no-secrets/no-secrets': 'warn',
         'sonarjs/no-nested-template-literals': 'off',
-        "security/detect-object-injection": "off",
+        'security/detect-object-injection': 'off',
 
         // Bundle size
         'no-unused-vars': [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.6.2",
+    "version": "0.7.0",
     "type": "commonjs",
     "name": "@okto-gmbh/eslint-config",
     "description": "ESLint and prettier config",


### PR DESCRIPTION
Enforces [object shorthand](https://eslint.org/docs/latest/rules/object-shorthand) with auto-fix.

```ts
// invalid
const obj = {
   prop: prop
}

// valid
const obj = {
  prop
}
```