### PR TITLE
fix: side effect imports should be first

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -71,6 +71,8 @@ module.exports = {
             'warn',
             {
                 groups: [
+                    // Side effect imports.
+                    ['^\\u0000'],
                     // Node.js builtins. You could also generate this regex if you use a `.js` config.
                     // For example: `^(${require("module").builtinModules.join("|")})(/|$)`
                     // Note that if you use the `node:` prefix for Node.js builtins,
@@ -86,8 +88,6 @@ module.exports = {
                     ['^@core(.*|$)'],
                     // Internal packages.
                     ['^(~)(.*|$)'],
-                    // Side effect imports.
-                    ['^\\u0000'],
                     // Parent imports. Put `..` last.
                     ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
                     // Other relative imports. Put same-folder imports and `.` last.


### PR DESCRIPTION
Side effect imports should come first.

```ts
import "some/side-effect";

import { somethingElse } from "some/module";
```