### PR TITLE
feat/tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ To configure the extension properly, create a `.vscode/settings.json` with the f
         "postcss"
     ],
 
+    // Tailwind CSS
+    "files.associations": {
+        "*.css": "tailwindcss"
+    },
+    "editor.quickSuggestions": {
+        "strings": true
+    },
+
     // Module import
     "typescript.preferences.importModuleSpecifier": "non-relative",
     "typescript.preferences.useAliasesForRenames": true

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -46,6 +46,7 @@ module.exports = {
         'yml',
         'tsdoc',
         'prettier',
+        'tailwindcss',
         'vitest'
     ],
     settings: {
@@ -161,6 +162,14 @@ module.exports = {
             'warn',
             { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }
         ],
+
+        // Tailwind CSS
+
+        'tailwindcss/classnames-order': 'warn',
+        'tailwindcss/enforces-negative-arbitrary-values': 'warn',
+        'tailwindcss/enforces-shorthand': 'warn',
+        'tailwindcss/no-contradicting-classname': 'warn',
+        'tailwindcss/no-custom-classname': 'off',
 
         // Vitest
         'vitest/expect-expect': 'warn',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.12.2",
+    "version": "0.13.0",
     "type": "commonjs",
     "name": "@okto-gmbh/eslint-config",
     "description": "ESLint and prettier config",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "eslint-plugin-sonarjs": "^0.19.0",
         "eslint-plugin-sort-destructure-keys": "^1.5.0",
         "eslint-plugin-sort-keys": "^2.3.5",
+        "eslint-plugin-tailwindcss": "^3.13.0",
         "eslint-plugin-tsdoc": "^0.2.17",
         "eslint-plugin-typescript-sort-keys": "^2.3.0",
         "eslint-plugin-unused-imports": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,14 @@ eslint-plugin-sort-keys@^2.3.5:
   dependencies:
     natural-compare "1.4.0"
 
+eslint-plugin-tailwindcss@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.13.0.tgz#60858cdc8888da2deda5f200c1b163b211c4b8fa"
+  integrity sha512-Fcep4KDRLWaK3KmkQbdyKHG0P4GdXFmXdDaweTIPcgOP60OOuWFbh1++dufRT28Q4zpKTKaHwTsXPJ4O/EjU2Q==
+  dependencies:
+    fast-glob "^3.2.5"
+    postcss "^8.4.4"
+
 eslint-plugin-tsdoc@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.17.tgz#27789495bbd8778abbf92db1707fec2ed3dfe281"
@@ -1773,6 +1781,17 @@ fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.5:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
+  integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -3062,6 +3081,15 @@ postcss@^8.3.11, postcss@^8.4.23, postcss@^8.4.24:
   version "8.4.24"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
   integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
+  dependencies:
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.4:
+  version "8.4.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.25.tgz#4a133f5e379eda7f61e906c3b1aaa9b81292726f"
+  integrity sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"


### PR DESCRIPTION
Adds eslint rules for tailwindcss.

The following options should also be added to a projects `.vscode/settings.json` file: 

```jsonc
// Tailwind CSS
"files.associations": {
    "*.css": "tailwindcss"
},
"editor.quickSuggestions": {
    "strings": true
}
```