### PR TITLE
fix: type imports

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -226,10 +226,8 @@ module.exports = {
                 'typescript-sort-keys/string-enum': 'warn',
 
                 // Type imports
-                '@typescript-eslint/consistent-type-imports': [
-                    'warn',
-                    { disallowTypeAnnotations: false }
-                ],
+                "import/consistent-type-specifier-style": ["warn", "prefer-top-level"],
+                '@typescript-eslint/consistent-type-imports': "warn",
 
                 // Quotes
                 quotes: 'off',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.13.4",
+    "version": "0.13.5",
     "type": "commonjs",
     "name": "@okto-gmbh/eslint-config",
     "description": "ESLint and prettier config",


### PR DESCRIPTION
Improves type imports

Before

```ts
import { type Foo, type Bar } from "module"
```

After

```ts
import type { Foo, Bar } from "module"
```